### PR TITLE
Use PUUID for Riot API rank requests

### DIFF
--- a/src/main/java/org/kiko/dev/RankService.java
+++ b/src/main/java/org/kiko/dev/RankService.java
@@ -197,12 +197,10 @@ public class RankService {
     }
 
     AccountInfo accountInfo = riotApiAdapter.getPuuid(name, tagline);
-    String encryptedSummonerId = riotApiAdapter.getEncryptedSummonerId(accountInfo.getPuuid());
 
-    List<RiotApiAdapter.LeagueEntry> entries = riotApiAdapter.getQueueRanks(encryptedSummonerId);
+    List<RiotApiAdapter.LeagueEntry> entries = riotApiAdapter.getQueueRanks(accountInfo.getPuuid());
 
-    savePlayerInformation(accountInfo.getPuuid(), accountInfo.getGameName(), accountInfo.getTagLine(), entries,
-        encryptedSummonerId);
+    savePlayerInformation(accountInfo.getPuuid(), accountInfo.getGameName(), accountInfo.getTagLine(), entries);
     return buildPlayerRankEmbed(accountInfo, entries);
   }
 
@@ -341,7 +339,7 @@ public class RankService {
    * Saves or updates a player's rank information in MongoDB.
    */
   private void savePlayerInformation(String puuid, String name, String tagline,
-      List<RiotApiAdapter.LeagueEntry> playerRanks, String encryptedSummonerId) {
+      List<RiotApiAdapter.LeagueEntry> playerRanks) {
     MongoDatabase database = mongoDbAdapter.getDatabase();
     MongoCollection<Document> collection = database
         .getCollection(SERVER_RANKS_COLLECTION + "-" + ContextHolder.getGuildId());
@@ -386,7 +384,6 @@ public class RankService {
     }
 
     Document playerDoc = new Document("puuid", puuid)
-        .append("encryptedSummonerId", encryptedSummonerId)
         .append("name", name)
         .append("tagline", tagline)
         .append("soloQRank", soloQRank)

--- a/src/main/java/org/kiko/dev/adapters/RiotApiAdapter.java
+++ b/src/main/java/org/kiko/dev/adapters/RiotApiAdapter.java
@@ -364,7 +364,8 @@ public class RiotApiAdapter {
     }
   }
 
-  public String getEncryptedSummonerId(String puuid) throws Exception {
+
+  public Optional<LeagueEntry> getSoloQueueRank(String puuid) throws Exception {
 
     while (true) {
       if (!simpleRateLimiter.canProceed(APP_LIMIT)) {
@@ -372,43 +373,8 @@ public class RiotApiAdapter {
         continue;
       }
 
-      String endpoint = String.format("/lol/summoner/v4/summoners/by-puuid/%s",
+      String endpoint = String.format("/lol/league/v4/entries/by-puuid/%s",
           URLEncoder.encode(puuid, StandardCharsets.UTF_8));
-
-      HttpRequest request = HttpRequest.newBuilder()
-          .uri(URI.create(ACCOUNT_BASE_URL + endpoint))
-          .header("X-Riot-Token", RIOT_API_KEY)
-          .GET()
-          .build();
-
-      HttpResponse<String> response = client.send(request,
-          HttpResponse.BodyHandlers.ofString());
-
-      simpleRateLimiter.updateRateLimit(APP_LIMIT, response);
-
-      if (response.statusCode() == HttpURLConnection.HTTP_OK) {
-        JsonObject jsonObject = gson.fromJson(response.body(), JsonObject.class);
-        return jsonObject.get("id").getAsString();
-      } else if (response.statusCode() == 429) { // Rate limit hit
-        continue; // Will retry after waiting
-
-      } else {
-        handleErrorResponse(response);
-        return null;
-      }
-    }
-  }
-
-  public Optional<LeagueEntry> getSoloQueueRank(String encryptedSummonerId) throws Exception {
-
-    while (true) {
-      if (!simpleRateLimiter.canProceed(APP_LIMIT)) {
-        simpleRateLimiter.awaitRateLimit(APP_LIMIT);
-        continue;
-      }
-
-      String endpoint = String.format("/lol/league/v4/entries/by-summoner/%s",
-          URLEncoder.encode(encryptedSummonerId, StandardCharsets.UTF_8));
 
       HttpRequest request = HttpRequest.newBuilder()
           .uri(URI.create(ACCOUNT_BASE_URL + endpoint))
@@ -443,7 +409,7 @@ public class RiotApiAdapter {
     }
   }
 
-  public Optional<LeagueEntry> getFlexQueueRank(String encryptedSummonerId) throws Exception {
+  public Optional<LeagueEntry> getFlexQueueRank(String puuid) throws Exception {
 
     while (true) {
       if (!simpleRateLimiter.canProceed(APP_LIMIT)) {
@@ -451,8 +417,8 @@ public class RiotApiAdapter {
         continue;
       }
 
-      String endpoint = String.format("/lol/league/v4/entries/by-summoner/%s",
-          URLEncoder.encode(encryptedSummonerId, StandardCharsets.UTF_8));
+      String endpoint = String.format("/lol/league/v4/entries/by-puuid/%s",
+          URLEncoder.encode(puuid, StandardCharsets.UTF_8));
 
       HttpRequest request = HttpRequest.newBuilder()
           .uri(URI.create(ACCOUNT_BASE_URL + endpoint))
@@ -487,7 +453,7 @@ public class RiotApiAdapter {
     }
   }
 
-  public List<LeagueEntry> getQueueRanks(String encryptedSummonerId) throws Exception {
+  public List<LeagueEntry> getQueueRanks(String puuid) throws Exception {
 
     while (true) {
       if (!simpleRateLimiter.canProceed(APP_LIMIT)) {
@@ -495,8 +461,8 @@ public class RiotApiAdapter {
         continue;
       }
 
-      String endpoint = String.format("/lol/league/v4/entries/by-summoner/%s",
-          URLEncoder.encode(encryptedSummonerId, StandardCharsets.UTF_8));
+      String endpoint = String.format("/lol/league/v4/entries/by-puuid/%s",
+          URLEncoder.encode(puuid, StandardCharsets.UTF_8));
 
       HttpRequest request = HttpRequest.newBuilder()
           .uri(URI.create(ACCOUNT_BASE_URL + endpoint))

--- a/src/main/java/org/kiko/dev/game_scanner/GameScanner.java
+++ b/src/main/java/org/kiko/dev/game_scanner/GameScanner.java
@@ -197,7 +197,7 @@ public class GameScanner {
                     // retrieve the players
                     mongoDbAdapter.getDatabase().getCollection(SERVER_RANKS_COLLECTION + "-" + ContextHolder.getGuildId()).find(filter).forEach(player -> {
                         try {
-                            updatePlayerRank(player.getString("puuid"), gameDoc.getString("queueType"), player.getString("encryptedSummonerId"));
+                            updatePlayerRank(player.getString("puuid"), gameDoc.getString("queueType"));
                         } catch (Exception e) {
                             throw new RuntimeException(e);
                         }
@@ -309,7 +309,7 @@ public class GameScanner {
                 .into(new ArrayList<>());
     }
 
-    private void updatePlayerRank(String puuid, String queueType, String encryptedSummonerId) throws Exception {
+    private void updatePlayerRank(String puuid, String queueType) throws Exception {
         int elo = 0;
         int wins = 0;
         int losses = 0;
@@ -320,7 +320,7 @@ public class GameScanner {
         RiotApiAdapter.LeagueEntry entry;
 
         if (queueType.equals("RANKED_SOLO/DUO")) {
-            optionalEntry = riotApiAdapter.getSoloQueueRank(encryptedSummonerId);
+            optionalEntry = riotApiAdapter.getSoloQueueRank(puuid);
             entry = optionalEntry.get();
             rank = String.format("%s %s %d LP",
                     entry.getTier(),
@@ -331,7 +331,7 @@ public class GameScanner {
             losses = entry.getLosses();
             winrate = wins > 0 ? (double) wins / (wins + losses) * 100 : 0.0;
         } else {
-            optionalEntry = riotApiAdapter.getFlexQueueRank(encryptedSummonerId);
+            optionalEntry = riotApiAdapter.getFlexQueueRank(puuid);
             entry = optionalEntry.get();
             rank = String.format("%s %s %d LP",
                     entry.getTier(),
@@ -476,8 +476,8 @@ public class GameScanner {
 
                 participant.setPlayerName(riotApiAdapter.getByPuuid(participant.getPuuid()).getGameName());
 
-                Optional<RiotApiAdapter.LeagueEntry> optionalEntry = queueType.equals("RANKED_FLEX") ? riotApiAdapter.getFlexQueueRank(participant.getSummonerId()) :
-                        riotApiAdapter.getSoloQueueRank(participant.getSummonerId());
+                Optional<RiotApiAdapter.LeagueEntry> optionalEntry = queueType.equals("RANKED_FLEX") ? riotApiAdapter.getFlexQueueRank(participant.getPuuid()) :
+                        riotApiAdapter.getSoloQueueRank(participant.getPuuid());
                 if (optionalEntry.isPresent()) {
                     RiotApiAdapter.LeagueEntry entry = optionalEntry.get();
                     participant.setRank(String.format("%s %s %d LP",


### PR DESCRIPTION
## Summary
- replace deprecated encryptedSummonerId usages with PUUID
- update rank retrieval and storage to rely on PUUID
- remove no-longer-used encrypted summoner id support

## Testing
- `mvn -q test` *(fails: Could not resolve maven-resources-plugin due to network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_688de0ecacf083209baa2f2b30fa06e2